### PR TITLE
Update sensor.py - [typo] Teamperature -> Temperature

### DIFF
--- a/custom_components/weatherflow_forecast/sensor.py
+++ b/custom_components/weatherflow_forecast/sensor.py
@@ -309,14 +309,14 @@ SENSOR_TYPES: tuple[WeatherFlowSensorEntityDescription, ...] = (
     ),
     WeatherFlowSensorEntityDescription(
         key="wet_bulb_globe_temperature",
-        name="Wet Bulb Globe Teamperature",
+        name="Wet Bulb Globe Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     WeatherFlowSensorEntityDescription(
         key="wet_bulb_temperature",
-        name="Wet Bulb Teamperature",
+        name="Wet Bulb Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
Hello. Thank you for this great work!

Noticed I had sensors named "teamperature", I believe this should fix if not let me know what else is needed or you may go ahead and push over my changes.

```
        "aliases": [],
        "area_id": null,
        "capabilities": {
          "state_class": "measurement"
        },
        "config_entry_id": "9600bccb7090972972915XXXXXXXXXX",
        "device_class": null,
        "device_id": "f88c407b537e65a4006XXXXXXXXXX",
        "disabled_by": null,
        "entity_category": null,
        "entity_id": "sensor.tmr_h3r_sensors_wet_bulb_teamperature",
        "hidden_by": null,
        "icon": null,
        "id": "b469204424716522ae9cd6XXXXXXXXX",
        "has_entity_name": true,
        "name": null,
        "options": {
          "conversation": {
            "should_expose": true
          }
        },
        "original_device_class": "temperature",
        "original_icon": null,
        "original_name": "Wet Bulb Teamperature",
        "platform": "weatherflow_forecast",
        "supported_features": 0,
        "translation_key": null,
        "unique_id": "101XXX wet_bulb_temperature",
        "unit_of_measurement": "°C"
      },
```