### PR TITLE
0.3.0 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
-## Release 0.2.3
+## Release 0.3.0
 
 Date: `NOT RELEASED`
 
 ### Changes
 - **BREAKING**
-  - Voltage and battery sensors are now added for Tempest devices. They will not appear until the Integration has been deleted and re-added, as necessary data is only read during config.
-  - Precipitation Minutes... sensors have been renamed. Please delete them manually
+  **Due to all the changes made in this release, I recommend that you remove the integration and re-add it. This will ensure all sensors are named correctly, and obsolete sensors are removed.**
+  - Precipitation Minutes... sensors have been renamed. Please delete them manually if you do not follow the recommendation above.
+  - Wet Bulb sensors have been renamed due to spelling error. You might need to delete the obsolete sensors manually.
 - Changed icon for Cloud Base
 - Add the Integration to the Default HACS store. (Not merged on release of this version)
-- Bump pyweatherflow-forecast to 0.5.0
+- Bump pyweatherflow-forecast to 0.6.0
 - Added `Voltage` sensor. This sensor will only be available for Tempest devices. There will be no implementation for AIR and SKY as these are deprecated devices.
 - Added `Battery` sensor. This sensor is derived from the Voltage sensor above and shows the % full based on voltage amount.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release 0.3.0
 
-Date: `NOT RELEASED`
+Date: `2023-10-14`
 
 ### Changes
 - **BREAKING**

--- a/custom_components/weatherflow_forecast/__init__.py
+++ b/custom_components/weatherflow_forecast/__init__.py
@@ -122,18 +122,14 @@ class WeatherFlowForecastWeatherData:
         self._weather_data: WeatherFlow
         self.current_weather_data: WeatherFlowForecastData = {}
         self.daily_forecast: WeatherFlowForecastDaily = []
-        self.device_id = None
         self.hourly_forecast: WeatherFlowForecastHourly = []
         self.sensor_data: WeatherFlowSensorData = {}
-        self.device_data: WeatherFlowDeviceData = {}
 
     def initialize_data(self) -> bool:
         """Establish connection to API."""
 
         self._weather_data = WeatherFlow(
             self._config[CONF_STATION_ID], self._config[CONF_API_TOKEN], elevation=self.hass.config.elevation, session=async_get_clientsession(self.hass))
-
-        self.device_id = self._config.get(CONF_DEVICE_ID, None)
 
         return True
 
@@ -163,26 +159,7 @@ class WeatherFlowForecastWeatherData:
 
         if self._add_sensors:
             try:
-                device_data: WeatherFlowDeviceData = await self._weather_data.async_get_device(self.device_id)
-            except WeatherFlowForecastWongStationId as unauthorized:
-                _LOGGER.debug(unauthorized)
-                raise Unauthorized from unauthorized
-            except WeatherFlowForecastBadRequest as err:
-                _LOGGER.debug(err)
-                return False
-            except WeatherFlowForecastUnauthorized as unauthorized:
-                _LOGGER.debug(unauthorized)
-                raise Unauthorized from unauthorized
-            except WeatherFlowForecastInternalServerError as notreadyerror:
-                _LOGGER.debug(notreadyerror)
-                raise ConfigEntryNotReady from notreadyerror
-
-            if not device_data:
-                raise CannotConnect()
-            self.device_data = device_data
-
-            try:
-                resp: WeatherFlowForecastData = await self._weather_data.async_get_sensors(self.device_data.voltage)
+                resp: WeatherFlowForecastData = await self._weather_data.async_fetch_sensor_data()
             except WeatherFlowForecastWongStationId as unauthorized:
                 _LOGGER.debug(unauthorized)
                 raise Unauthorized from unauthorized

--- a/custom_components/weatherflow_forecast/__init__.py
+++ b/custom_components/weatherflow_forecast/__init__.py
@@ -9,7 +9,6 @@ from typing import Any, Self
 
 from pyweatherflow_forecast import (
     WeatherFlow,
-    WeatherFlowDeviceData,
     WeatherFlowForecastData,
     WeatherFlowForecastDaily,
     WeatherFlowForecastHourly,
@@ -18,7 +17,6 @@ from pyweatherflow_forecast import (
     WeatherFlowForecastInternalServerError,
     WeatherFlowForecastWongStationId,
     WeatherFlowSensorData,
-    WeatherFlowStationData,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -33,7 +31,6 @@ from .const import (
     DOMAIN,
     CONF_ADD_SENSORS,
     CONF_API_TOKEN,
-    CONF_DEVICE_ID,
     CONF_STATION_ID,
 )
 

--- a/custom_components/weatherflow_forecast/config_flow.py
+++ b/custom_components/weatherflow_forecast/config_flow.py
@@ -23,6 +23,8 @@ from .const import (
     CONF_ADD_SENSORS,
     CONF_API_TOKEN,
     CONF_DEVICE_ID,
+    CONF_FIRMWARE_REVISION,
+    CONF_SERIAL_NUMBER,
     CONF_STATION_ID,
 )
 
@@ -81,6 +83,8 @@ class WeatherFlowForecastHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_STATION_ID: user_input[CONF_STATION_ID],
                 CONF_API_TOKEN: user_input[CONF_API_TOKEN],
                 CONF_DEVICE_ID: station_data.device_id,
+                CONF_FIRMWARE_REVISION: station_data.firmware_revision,
+                CONF_SERIAL_NUMBER: station_data.serial_number,
             },
             options={
                 CONF_ADD_SENSORS: user_input[CONF_ADD_SENSORS],

--- a/custom_components/weatherflow_forecast/const.py
+++ b/custom_components/weatherflow_forecast/const.py
@@ -6,6 +6,8 @@ CONCENTRATION_GRAMS_PER_CUBIC_METER = "g/m³"
 CONF_ADD_SENSORS = "add_sensors"
 CONF_API_TOKEN = "api_token"
 CONF_DEVICE_ID = "device_id"
+CONF_FIRMWARE_REVISION = "firmware_revision"
+CONF_SERIAL_NUMBER = "serial_number"
 CONF_STATION_ID = "station_id"
 
 DEFAULT_ADD_SENSOR = False

--- a/custom_components/weatherflow_forecast/sensor.py
+++ b/custom_components/weatherflow_forecast/sensor.py
@@ -315,14 +315,14 @@ SENSOR_TYPES: tuple[WeatherFlowSensorEntityDescription, ...] = (
     ),
     WeatherFlowSensorEntityDescription(
         key="wet_bulb_globe_temperature",
-        name="Wet Bulb Globe Teamperature",
+        name="Wet Bulb Globe Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     WeatherFlowSensorEntityDescription(
         key="wet_bulb_temperature",
-        name="Wet Bulb Teamperature",
+        name="Wet Bulb Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/weatherflow_forecast/sensor.py
+++ b/custom_components/weatherflow_forecast/sensor.py
@@ -46,6 +46,7 @@ from . import WeatherFlowForecastDataUpdateCoordinator
 from .const import (
     ATTR_ATTRIBUTION,
     CONCENTRATION_GRAMS_PER_CUBIC_METER,
+    CONF_FIRMWARE_REVISION,
     CONF_STATION_ID,
     DOMAIN,
     MANUFACTURER,
@@ -426,6 +427,7 @@ class WeatherFlowSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
             model=MODEL,
             name=f"{self._config.data[CONF_NAME]} Sensors",
             configuration_url=f"https://tempestwx.com/station/{self._config.data[CONF_STATION_ID]}/grid",
+            hw_version=f"FW V{self._config.data.get(CONF_FIRMWARE_REVISION, ' - Not Available')}",
         )
         self._attr_attribution = ATTR_ATTRIBUTION
         self._attr_unique_id = f"{config.data[CONF_STATION_ID]} {description.key}"

--- a/custom_components/weatherflow_forecast/sensor.py
+++ b/custom_components/weatherflow_forecast/sensor.py
@@ -90,6 +90,14 @@ SENSOR_TYPES: tuple[WeatherFlowSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
     ),
     WeatherFlowSensorEntityDescription(
+        key="battery",
+        name="Battery",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+    ),
+    WeatherFlowSensorEntityDescription(
         key="beaufort",
         name="Beaufort",
         icon="mdi:windsock",
@@ -314,6 +322,14 @@ SENSOR_TYPES: tuple[WeatherFlowSensorEntityDescription, ...] = (
         suggested_display_precision=0,
     ),
     WeatherFlowSensorEntityDescription(
+        key="voltage",
+        name="Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    WeatherFlowSensorEntityDescription(
         key="wet_bulb_globe_temperature",
         name="Wet Bulb Globe Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -368,22 +384,6 @@ SENSOR_TYPES: tuple[WeatherFlowSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.WIND_SPEED,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    WeatherFlowSensorEntityDescription(
-        key="battery",
-        name="Battery",
-        native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.BATTERY,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=0,
-    ),
-    WeatherFlowSensorEntityDescription(
-        key="voltage",
-        name="Voltage",
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        suggested_display_precision=2,
-    )
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/weatherflow_forecast/weather.py
+++ b/custom_components/weatherflow_forecast/weather.py
@@ -30,6 +30,7 @@ from homeassistant.util.dt import utc_from_timestamp
 from . import WeatherFlowForecastDataUpdateCoordinator
 from .const import (
     ATTR_ATTRIBUTION,
+    CONF_FIRMWARE_REVISION,
     CONF_STATION_ID,
     DEFAULT_NAME,
     DOMAIN,
@@ -118,6 +119,7 @@ class WeatherFlowWeather(SingleCoordinatorWeatherEntity[WeatherFlowForecastDataU
             manufacturer=MANUFACTURER,
             model=MODEL,
             configuration_url=f"https://tempestwx.com/station/{self._config[CONF_STATION_ID]}/grid",
+            hw_version=f"FW V{self._config.get(CONF_FIRMWARE_REVISION, ' - Not Available')}",
         )
 
     @property


### PR DESCRIPTION
- **BREAKING**
  **Due to all the changes made in this release, I recommend that you remove the integration and re-add it. This will ensure all sensors are named correctly, and obsolete sensors are removed.**
  - Precipitation Minutes... sensors have been renamed. Please delete them manually if you do not follow the recommendation above.
  - Wet Bulb sensors have been renamed due to spelling error. You might need to delete the obsolete sensors manually.
- Changed icon for Cloud Base
- Add the Integration to the Default HACS store. (Not merged on release of this version)
- Bump pyweatherflow-forecast to 0.6.0
- Added `Voltage` sensor. This sensor will only be available for Tempest devices. There will be no implementation for AIR and SKY as these are deprecated devices.
- Added `Battery` sensor. This sensor is derived from the Voltage sensor above and shows the % full based on voltage amount.