### PR TITLE
0.3.1 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ Date: `NOT RELEASED`
 
 ### TODO
 - If sensors have been installed, and the user selectes to remove them again, ensure they are deleted from Home Assistant. Currently they must be manually removed.
-- Migrate parts of the language files from the 'old' integration. I will still need people to do some translations.
-- If Station ID and API Token do not match, a wrong error message is displayed.
 
 ## Release 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Date: `NOT RELEASED`
 ### Changes
 
 - Bump pyweatherflow-forecast to 0.6.1, which optimizes the number of calls to the WeatherFlow Rest API, by removing 1 call per cycle
+- Bump pyweatherflow-forecast to 0.6.2, to ensure that AIR and SKY devices still can work with sensors, even without Voltage and Battery information.
 - Added language file for the following language codes: **cs, de, it, nl, sv**. Please note that not all translations are complete in these files, so anyone with the knowledge of the languages, please fork this repo, change the text strings, and make a Pull Request.
 
 ### TODO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release 0.3.1
 
-Date: `NOT RELEASED`
+Date: `2023-10-15`
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Date: `NOT RELEASED`
 
 ### Changes
 
-- Bump pyweatherflow-forecast to 0.6.1, which optimizes the number of calls to the WeatherFlow, by removing 1 call per cycle
+- Bump pyweatherflow-forecast to 0.6.1, which optimizes the number of calls to the WeatherFlow Rest API, by removing 1 call per cycle
 - Added language file for the following language codes: **cs, de, it, nl, sv**. Please note that not all translations are complete in these files, so anyone with the knowledge of the languages, please fork this repo, change the text strings, and make a Pull Request.
 
 ### TODO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Release 0.3.1
+
+Date: `NOT RELEASED`
+
+### Changes
+
+- Bump pyweatherflow-forecast to 0.6.1, which optimizes the number of calls to the WeatherFlow, by removing 1 call per cycle
+- Added language file for the following language codes: **cs, de, it, nl, sv**. Please note that not all translations are complete in these files, so anyone with the knowledge of the languages, please fork this repo, change the text strings, and make a Pull Request.
+
+### TODO
+- If sensors have been installed, and the user selectes to remove them again, ensure they are deleted from Home Assistant. Currently they must be manually removed.
+- Migrate parts of the language files from the 'old' integration. I will still need people to do some translations.
+- If Station ID and API Token do not match, a wrong error message is displayed.
+
 ## Release 0.3.0
 
 Date: `2023-10-14`
@@ -12,11 +26,6 @@ Date: `2023-10-14`
 - Bump pyweatherflow-forecast to 0.6.0
 - Added `Voltage` sensor. This sensor will only be available for Tempest devices. There will be no implementation for AIR and SKY as these are deprecated devices.
 - Added `Battery` sensor. This sensor is derived from the Voltage sensor above and shows the % full based on voltage amount.
-
-### TODO
-- If sensors have been installed, and the user selectes to remove them again, ensure they are deleted from Home Assistant. Currently they must be manually removed.
-- Migrate parts of the language files from the 'old' integration. I will still need people to do some translations.
-- If Station ID and API Token do not match, a wrong error message is displayed.
 
 ## Release 0.2.2
 

--- a/custom_components/weatherflow_forecast/manifest.json
+++ b/custom_components/weatherflow_forecast/manifest.json
@@ -10,7 +10,7 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/briis/weatherflow_forecast/issues",
     "requirements": [
-        "pyweatherflow-forecast==0.6.1"
+        "pyweatherflow-forecast==0.6.2"
     ],
     "version": "0.3.1"
 }

--- a/custom_components/weatherflow_forecast/manifest.json
+++ b/custom_components/weatherflow_forecast/manifest.json
@@ -10,7 +10,7 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/briis/weatherflow_forecast/issues",
     "requirements": [
-        "pyweatherflow-forecast==0.6.0"
+        "pyweatherflow-forecast==0.6.1"
     ],
-    "version": "0.3.0"
+    "version": "0.3.1"
 }

--- a/custom_components/weatherflow_forecast/translations/cs.json
+++ b/custom_components/weatherflow_forecast/translations/cs.json
@@ -1,0 +1,65 @@
+{
+    "config": {
+        "abort": {
+            "unique_id": "Stanice WeatherFlow už je nakonfigurovaná."
+        },
+        "error": {
+            "wrong_station_id": "Zadané Station Id je chybné.",
+            "server_error": "WeatherFlow servers encountered an unexpected error",
+            "wrong_token": "Zadaný Api Token je chybný.",
+            "bad_request": "Nastala neznámá chyba při přenosu dat."
+        },
+        "step": {
+            "user": {
+                "description": "Nastavit Stanici WeatherFlow Forecast",
+                "title": "WeatherFlow Forecast",
+                "data": {
+                    "station_id": "Station Id",
+                    "api_token": "Osobní Api Token",
+                    "add_sensors": "Add sensors from the Weather Station"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "api_token": "Osobní Api Token",
+                    "add_sensors": "Add sensors from the Weather Station"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "pressure_trend": {
+                "state": {
+                    "falling": "Klesající",
+                    "rising": "Rostoucí",
+                    "steady": "Stabilní"
+                }
+            },
+            "wind_cardinal": {
+                "state": {
+                    "n": "S",
+                    "nne": "SSV",
+                    "ne": "SV",
+                    "ene": "VSV",
+                    "e": "V",
+                    "ese": "VJV",
+                    "se": "JV",
+                    "sse": "JJV",
+                    "s": "J",
+                    "ssw": "JJZ",
+                    "sw": "JZ",
+                    "wsw": "ZJZ",
+                    "w": "Z",
+                    "wnw": "ZSZ",
+                    "nw": "SZ",
+                    "nnw": "SSZ"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/weatherflow_forecast/translations/de.json
+++ b/custom_components/weatherflow_forecast/translations/de.json
@@ -1,0 +1,65 @@
+{
+    "config": {
+        "abort": {
+            "unique_id": "WeatherFlow-Station wurde bereits konfiguriert."
+        },
+        "error": {
+            "wrong_station_id": "Die Station-Id ist falsch.",
+            "server_error": "WeatherFlow servers encountered an unexpected error",
+            "wrong_token": "Der eingegebene Api-Token ist nicht korrekt.",
+            "bad_request": "Ein unbekannter Fehler ist beim Empfang von Daten aufgetreten."
+        },
+        "step": {
+            "user": {
+                "description": "Einrichten einer WeatherFlow Forecast-Station",
+                "title": "WeatherFlow Forecast",
+                "data": {
+                    "station_id": "Station-Id",
+                    "api_token": "Persönlicher Api-Token",
+                    "add_sensors": "Add sensors from the Weather Station"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "api_token": "Persönlicher Api-Token",
+                    "add_sensors": "Add sensors from the Weather Station"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "pressure_trend": {
+                "state": {
+                    "falling": "fallend",
+                    "rising": "steigend",
+                    "steady": "stetig"
+                }
+            },
+            "wind_cardinal": {
+                "state": {
+                    "n": "N",
+                    "nne": "NNO",
+                    "ne": "NO",
+                    "ene": "ONO",
+                    "e": "O",
+                    "ese": "OSO",
+                    "se": "SO",
+                    "sse": "SSO",
+                    "s": "S",
+                    "ssw": "SSW",
+                    "sw": "SW",
+                    "wsw": "WSW",
+                    "w": "W",
+                    "wnw": "WNW",
+                    "nw": "NW",
+                    "nnw": "NNW"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/weatherflow_forecast/translations/it.json
+++ b/custom_components/weatherflow_forecast/translations/it.json
@@ -1,0 +1,65 @@
+{
+    "config": {
+        "abort": {
+            "unique_id": "La stazione WeatherFlow è già stata configurata."
+        },
+        "error": {
+            "wrong_station_id": "L'ID della stazione non è corretto.",
+            "server_error": "WeatherFlow servers encountered an unexpected error",
+            "wrong_token": "Il Token API inserito non è corretto.",
+            "bad_request": "Errore sconosciuto in fase di accesso ai dati."
+        },
+        "step": {
+            "user": {
+                "description": "Configurazione della stazione WeatherFlow Forecast",
+                "title": "WeatherFlow Forecast",
+                "data": {
+                    "station_id": "ID stazione",
+                    "api_token": "Token API personale",
+                    "add_sensors": "Add sensors from the Weather Station"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "api_token": "Token API personale",
+                    "add_sensors": "Add sensors from the Weather Station"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "pressure_trend": {
+                "state": {
+                    "falling": "Discendente",
+                    "rising": "Ascendente",
+                    "steady": "Stabile"
+                }
+            },
+            "wind_cardinal": {
+                "state": {
+                    "n": "N",
+                    "nne": "NNE",
+                    "ne": "NE",
+                    "ene": "ENE",
+                    "e": "E",
+                    "ese": "ESE",
+                    "se": "SE",
+                    "sse": "SSE",
+                    "s": "S",
+                    "ssw": "SSO",
+                    "sw": "SO",
+                    "wsw": "OSO",
+                    "w": "O",
+                    "wnw": "ONO",
+                    "nw": "NO",
+                    "nnw": "NNO"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/weatherflow_forecast/translations/nl.json
+++ b/custom_components/weatherflow_forecast/translations/nl.json
@@ -1,0 +1,65 @@
+{
+    "config": {
+        "abort": {
+            "unique_id": "WeatherFlow station is reeds geconfigured."
+        },
+        "error": {
+            "wrong_station_id": "De Station Id is niet juist.",
+            "server_error": "WeatherFlow servers encountered an unexpected error",
+            "wrong_token": "Het Api Token is niet juist.",
+            "bad_request": "Een onbekende fout in opgetreden tijdens het ophalen van de gegevens."
+        },
+        "step": {
+            "user": {
+                "description": "Configuratie van een WeatherFlow Forecast station",
+                "title": "WeatherFlow Forecast",
+                "data": {
+                    "station_id": "Station Id",
+                    "api_token": "Personal Api Token",
+                    "add_sensors": "Add sensors from the Weather Station"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "api_token": "Personal Api Token",
+                    "add_sensors": "Add sensors from the Weather Station"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "pressure_trend": {
+                "state": {
+                    "falling": "Dalend",
+                    "rising": "Stijgend",
+                    "steady": "Constant"
+                }
+            },
+            "wind_cardinal": {
+                "state": {
+                    "n": "N",
+                    "nne": "NNO",
+                    "ne": "NO",
+                    "ene": "ONO",
+                    "e": "O",
+                    "ese": "OZO",
+                    "se": "ZO",
+                    "sse": "ZZO",
+                    "s": "Z",
+                    "ssw": "ZZW",
+                    "sw": "ZW",
+                    "wsw": "WZW",
+                    "w": "W",
+                    "wnw": "WNW",
+                    "nw": "NW",
+                    "nnw": "NNW"
+                }
+            }
+        }
+    }
+}

--- a/custom_components/weatherflow_forecast/translations/sv.json
+++ b/custom_components/weatherflow_forecast/translations/sv.json
@@ -1,0 +1,65 @@
+{
+    "config": {
+        "abort": {
+            "unique_id": "Denna WeatherFlow Station är redan konfigurerad."
+        },
+        "error": {
+            "wrong_station_id": "Angivet Stations-ID är inte korrekt.",
+            "server_error": "WeatherFlow servers encountered an unexpected error",
+            "wrong_token": "Angiven API-token är inte korrekt.",
+            "bad_request": "Ett okänt fel uppstod under inhämtning av data."
+        },
+        "step": {
+            "user": {
+                "description": "Konfigurera en WeatherFlow Forecast Station",
+                "title": "WeatherFlow Forecast",
+                "data": {
+                    "station_id": "Station-Id",
+                    "api_token": "Personlig API-Token",
+                    "add_sensors": "Add sensors from the Weather Station"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "api_token": "Personlig API-Token",
+                    "add_sensors": "Add sensors from the Weather Station"
+                }
+            }
+        }
+    },
+    "entity": {
+        "sensor": {
+            "pressure_trend": {
+                "state": {
+                    "falling": "Fallande",
+                    "rising": "Stigande",
+                    "steady": "Stabil"
+                }
+            },
+            "wind_cardinal": {
+                "state": {
+                    "n": "N",
+                    "nne": "NNO",
+                    "ne": "NO",
+                    "ene": "ONO",
+                    "e": "Ö",
+                    "ese": "OSO",
+                    "se": "SO",
+                    "sse": "SSO",
+                    "s": "S",
+                    "ssw": "SSV",
+                    "sw": "SV",
+                    "wsw": "VSV",
+                    "w": "V",
+                    "wnw": "VNV",
+                    "nw": "NV",
+                    "nnw": "NNV"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Bump pyweatherflow-forecast to 0.6.1, which optimizes the number of calls to the WeatherFlow Rest API, by removing 1 call per cycle
- Bump pyweatherflow-forecast to 0.6.2, to ensure that AIR and SKY devices still can work with sensors, even without Voltage and Battery information.
- Added language file for the following language codes: **cs, de, it, nl, sv**. Please note that not all translations are complete in these files, so anyone with the knowledge of the languages, please fork this repo, change the text strings, and make a Pull Request.
