### PR TITLE
Add device class for wind direction sensor

### DIFF
--- a/custom_components/weatherflow_forecast/sensor.py
+++ b/custom_components/weatherflow_forecast/sensor.py
@@ -415,8 +415,8 @@ SENSOR_TYPES: tuple[WeatherFlowSensorEntityDescription, ...] = (
         key="wind_direction",
         name="Wind Direction",
         native_unit_of_measurement=DEGREE,
+        device_class=SensorDeviceClass.WIND_DIRECTION,
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:compass",
     ),
     WeatherFlowSensorEntityDescription(
         key="wind_gust",


### PR DESCRIPTION
Adding device class of wind_direction, and removing the icon definition makes HA display a dynamic icon that is an arrow pointing in one of 8 compass headings in the direction of wind flow.