### PR TITLE
Fix state_class for Wind Direction sensor (MEASUREMENT_ANGLE)

### DIFF
--- a/custom_components/weatherflow_forecast/sensor.py
+++ b/custom_components/weatherflow_forecast/sensor.py
@@ -416,7 +416,7 @@ SENSOR_TYPES: tuple[WeatherFlowSensorEntityDescription, ...] = (
         name="Wind Direction",
         native_unit_of_measurement=DEGREE,
         device_class=SensorDeviceClass.WIND_DIRECTION,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.MEASUREMENT_ANGLE,
     ),
     WeatherFlowSensorEntityDescription(
         key="wind_gust",


### PR DESCRIPTION
## Problem

PR #336 (released in 1.0.15) added `SensorDeviceClass.WIND_DIRECTION` to the Wind Direction sensor, but kept `state_class=SensorStateClass.MEASUREMENT`. Home Assistant requires `MEASUREMENT_ANGLE` for that device class, so on HA 2026.6 every startup logs:

```
Entity sensor.<station>_wind_direction (WeatherFlowSensor) is using state class 'measurement'
which is impossible considering device class ('wind_direction') it is using;
expected None or one of 'measurement_angle'
```

## Fix

Change the Wind Direction sensor description to `state_class=SensorStateClass.MEASUREMENT_ANGLE`, which is the state class HA expects for angular measurements (and what HA core weather integrations use for wind direction).

## Testing

Verified on Home Assistant 2026.6.2 with a live Tempest station (sensors enabled): before the change the warning above is logged at sensor setup; after the change the sensor is created cleanly and reports wind direction in degrees as before. Long-term statistics for angular measurements are handled correctly by the `measurement_angle` state class.
