### PR TITLE
Migrate legacy integer unique_id to string on setup

### DIFF
--- a/custom_components/weatherflow_forecast/__init__.py
+++ b/custom_components/weatherflow_forecast/__init__.py
@@ -63,6 +63,18 @@ def _get_forecast_hours(config_entry: ConfigEntry) -> int:
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up WeatherFlow Forecast as config entry."""
     hass.data.setdefault(DOMAIN, {})
+
+    # Coerce legacy non-string unique_id to a string. Entries created before the
+    # config flow started casting the station id (commit 73213aa) stored it as an
+    # int, which Home Assistant now flags on every load. There is no migration for
+    # those existing entries, so fix them up in place here.
+    if config_entry.unique_id is not None and not isinstance(
+        config_entry.unique_id, str
+    ):
+        hass.config_entries.async_update_entry(
+            config_entry, unique_id=str(config_entry.unique_id)
+        )
+
     integration = await async_get_integration(hass, DOMAIN)
     _LOGGER.info(STARTUP, integration.version, str(config_entry.data[CONF_STATION_ID]))
 


### PR DESCRIPTION
### What this fixes

Closes #345.

The config flow has cast the station id to `str` since commit 73213aa ("Fixing invalid unique_id of type 'int'"), so **new** entries are fine. But there's no migration for entries created before that change — they keep an `int` `unique_id` in `.storage`, and Home Assistant flags it on every load:

```
ERROR [homeassistant.config_entries] Config entry 'Home Weather Station' ... has an invalid unique_id '<station_id>' of type int when a string is expected ...
```

HA is deprecating non-string unique_ids, so these legacy entries will eventually fail to load entirely.

### The change

Coerce a non-string `unique_id` to `str` once, in `async_setup_entry`, before anything else runs:

```python
if config_entry.unique_id is not None and not isinstance(config_entry.unique_id, str):
    hass.config_entries.async_update_entry(
        config_entry, unique_id=str(config_entry.unique_id)
    )
```

New entries are unaffected (their `unique_id` is already a `str`, so the branch is skipped). I didn't bump the config-entry `VERSION` since this is an idempotent in-place coercion rather than a schema migration, but happy to move it into `async_migrate_entry` instead if you'd prefer that pattern.

---
*Authored by Claude (claude-opus-4-8) on behalf of the account owner, while diagnosing a separate forecast-parser failure on the owner's system. I confirmed via `git log` that the config flow already casts to `str` (commit 73213aa) and that no migration exists for pre-existing entries, which is why the owner's long-lived entry still emits the error. Lint wasn't run locally (ruff unavailable in the environment) — relying on CI. Opened with the owner's review and authorization.*
